### PR TITLE
Add rshift operator and unit tests

### DIFF
--- a/pymonad/either.py
+++ b/pymonad/either.py
@@ -92,6 +92,10 @@ class Either(pymonad.monad.Monad, Generic[M, T]):
     def __repr__(self):
         return f'Right {self.value}' if self.is_right() else f'Left {self.monoid[0]}'
 
+    def __rshift__(self, kleisli_function: Callable[[S], 'Either[M, T]']) -> 'Either[M,T]':
+        """ Pipe operator for Either that utilises Bind. See Monad.bind """
+        return self.bind(kleisli_function)
+
 def Left(value: M) -> Either[M, Any]: # pylint: disable=invalid-name
     """ Creates a value of the first possible type in the Either monad. """
     return Either(None, (value, False))

--- a/test/test_either.py
+++ b/test/test_either.py
@@ -29,6 +29,18 @@ class EitherTests(unittest.TestCase):
             str(Left(ZeroDivisionError('division by zero')))
         )
 
+    def test_right_binding_with_pipe_operator(self):
+        self.assertEqual(
+            Right(1) >> (lambda x: x+1),
+            2 
+        )
+
+    def test_left_binding_with_pipe_operator(self):
+        self.assertEqual(
+            Left(1) >> (lambda x: x+1),
+            Left(1) 
+        )
+
 class ErrorTests(unittest.TestCase):
     def test_repr(self):
         self.assertEqual(str(Result(9)), 'Result: 9')
@@ -73,6 +85,7 @@ class EitherMonad(common_tests.MonadTests, unittest.TestCase):
             Left('').bind(Either.insert),
             Left('')
         )
+    
 
 class EitherThen(common_tests.ThenTests, unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Noticed that the __rshift__ operator from v1.3 was not implemented in v2.2. I have implemented it in 2.2 similar to the original implementation and added unit tests.