### PR TITLE
[MISC] async_func decorator to seamlessly switch to promised argument…

### DIFF
--- a/test/test_promise.py
+++ b/test/test_promise.py
@@ -124,3 +124,30 @@ class PromiseThenTests(unittest.TestCase):
             _run(self._class.insert(0).then(inc)),
             _run(inc(0))
         )
+
+from pymonad.tools import async_func
+
+def my_func(x: int, y: int = 1, z: int = 1):
+    return (x + 2 * y) / z
+
+async_my_func = async_func(my_func)
+
+class PromiseAlgebraFunctions(unittest.TestCase):
+
+    def setUp(self):
+        self._class = _Promise
+
+    @staticmethod
+    async def add_one(x: int):
+        await asyncio.sleep((x % 10)/100)
+        return x + 1
+
+    def test_compose_promises(self):
+        self.assertEqual(
+            _run(async_my_func(
+                self._class.insert(1).map(self.add_one), z=self._class.insert(2)
+            ).map(self.add_one)), my_func(x=2, z=2) + 1
+        )
+
+
+


### PR DESCRIPTION
…s and outputs

While trying out and exploring the library I came across an issue which led to this PR. As is, the applicative version of the Promises does not allow for actual async execution. The example which is included in the library 

```
x = (Promise.insert(1)
                .then(long_id))
y = (Promise
        .insert(2)
        .then(long_id)
        .then(div(0))            # Raises an error...
        .catch(lambda error: 2)) # ...which is dealth with here.
print(
    await Promise.apply(add)
    .to_arguments(x, y)
    .catch(lambda error: 'Recovering...') 
```

does not seem to be truly async. In fact, the resolution of the arguments is sequential. If you were to place a print in the "long_id" function, you'll see that the second promises get executed once the first has finished. To address this and also allow to seamlessly transform "standard" functions to functions that use promises, I came up with this decorator which I show case in the following example:

```
@async_func
def add(x, y):
    return x+y

x = (Promise.insert(1)
                .then(long_id))
y = (Promise
        .insert(2)
        .then(long_id)
        .then(div(0))            # Raises an error...
        .catch(lambda error: 2)) # ...which is dealth with here.

z = add(x, y)

#z is a Promise object

print( await z.map(long_id).catch(lambda error: 'Recovering...') )
```

The computation of `z` is now truly async and can be applied to any function, with *args* or *kwargs* arguments.

If you like this feature, please point me where you'd prefer to get the function as well as the tests. Right now, I placed the code where it seemed more natural to me, but I'd trust your judgement where the best place would be 

  

 