### PR TITLE
[MISC] Avoid circular dependencies

### DIFF
--- a/pymonad/tools.py
+++ b/pymonad/tools.py
@@ -4,12 +4,9 @@
 # --------------------------------------------------------
 """ The tools module contains useful functions that don't really belong anywhere else. """
 
-from typing import Any, Callable, List, TypeVar, Awaitable
+from typing import Any, Callable, List, TypeVar
 
-import asyncio
 import pymonad.monad as monad
-
-from pymonad.promise import Promise, _Promise
 
 R = TypeVar('R') # pylint: disable=invalid-name
 S = TypeVar('S') # pylint: disable=invalid-name
@@ -163,64 +160,3 @@ def monad_from_none_or_value(
     else:
         return if_value(value)
 
-
-
-def async_func(func: Callable) -> Callable:
-    """Transform simple function in async function using promises.
-
-    async_func is supposed to be used as a decorator for providing
-    seamless integration with asynchronous operations, by deferring
-    arguments and keyword arguments input to be scheduled asynchronously
-    into the event-loop. It also transform the output into a promise,
-    allowing for abstract computation.
-
-    Example:
-      @async_func
-      def add(x, y):
-          return x+y
-
-      x = (Promise.insert(1)
-                      .then(long_id))
-      y = (Promise
-              .insert(2)
-              .then(long_id)
-              .then(div(0))            # Raises an error...
-              .catch(lambda error: 2)) # ...which is dealth with here.
-
-      z = add(x, y)
-
-      # z is now a Promise object that can be further used into other
-      # operations, abstracting chain of computations
-
-      print( await z.map(long_id).catch(lambda error: 'Recovering...') )
-
-    Args:
-      func: a regular function with variable arguments args and keyword
-            arguments kwargs
-
-     Returns:
-      An asynchronous counterpart of the provided function, that
-      accepts both promise and/or regular values and  returns promises,
-      for asynchronous usage
-
-    """
-
-    async def getArgs(args):
-        return await asyncio.gather(
-            *[arg if isinstance(arg, Awaitable) else Promise.insert(arg) for arg in args]
-        )
-
-    async def getKwargs(kwargs):
-        kwargsTasks = [arg.map(lambda x: (ith, x)) if isinstance(arg, Awaitable) else Promise.insert((ith, arg))
-                       for ith, arg in kwargs.items()]
-        return dict(await asyncio.gather(*kwargsTasks))
-
-    async def async_wrap(*args, **kwargs):
-        (_args, _kwargs) = await asyncio.gather(getArgs(args), getKwargs(kwargs))
-
-        return func(*_args, **_kwargs)
-
-    def wrapper(*args, **kwargs):
-        return _Promise(lambda resolve, reject: async_wrap(*args, **kwargs), None)
-
-    return wrapper

--- a/test/test_promise.py
+++ b/test/test_promise.py
@@ -125,7 +125,7 @@ class PromiseThenTests(unittest.TestCase):
             _run(inc(0))
         )
 
-from pymonad.tools import async_func
+from pymonad.promise import async_func
 
 def my_func(x: int, y: int = 1, z: int = 1):
     return (x + 2 * y) / z


### PR DESCRIPTION
Hi @jasondelaat 

I just realized that I introduced a circular dependencies with the previous commit (strange that we did not notice this though...) that was breaking the code as: `pymonad.promise` needs `pymonad.tools` that needs `pymonad.promise` (hence the circularity)

I suppose it would be best to place the `async_func` decorator in the promise module directly. 

This PR is to make up for such a circular dependency

